### PR TITLE
feat: add ConfirmModal and InputModal components

### DIFF
--- a/src/components/ConfirmModal.tsx
+++ b/src/components/ConfirmModal.tsx
@@ -1,0 +1,104 @@
+"use client";
+import React from "react";
+import toast from "react-hot-toast";
+
+interface ConfirmModalProps {
+  isOpen: boolean;
+  title?: string;
+  message?: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+  showDefaultToast?: boolean; // control generic success toast
+}
+
+export default function ConfirmModal({
+  isOpen,
+  title = "Are you sure?",
+  message = "This action cannot be undone.",
+  onConfirm,
+  onCancel,
+  showDefaultToast = true,
+}: ConfirmModalProps) {
+  if (!isOpen) return null;
+
+  const handleConfirm = async () => {
+    await onConfirm();
+    if (showDefaultToast) {
+      toast.success("Action confirmed!");
+    }
+  };
+
+  const handleCancel = () => {
+    onCancel();
+    if (showDefaultToast) {
+      toast("Action canceled", { icon: "⚪" });
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-4 animate-in fade-in duration-200"
+      role="presentation"
+      aria-hidden="false"
+    >
+      <dialog
+        open={isOpen}
+        className="bg-white dark:bg-gray-800 rounded-xl shadow-2xl p-6 w-full max-w-md mx-auto transform animate-in zoom-in-95 duration-200"
+        role="alertdialog"
+        aria-labelledby="confirm-modal-title"
+        aria-describedby="confirm-modal-description"
+        aria-modal="true"
+      >
+        <header className="flex items-center justify-center w-12 h-12 mx-auto mb-4 bg-red-100 dark:bg-red-900/30 rounded-full">
+          <svg
+            className="w-6 h-6 text-red-600 dark:text-red-400"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z"
+            />
+          </svg>
+        </header>
+
+        <main className="text-center mb-6">
+          <h2
+            id="confirm-modal-title"
+            className="text-xl font-semibold mb-2 text-gray-900 dark:text-gray-100"
+          >
+            {title}
+          </h2>
+          <p
+            id="confirm-modal-description"
+            className="text-sm text-gray-600 dark:text-gray-300 leading-relaxed"
+          >
+            {message}
+          </p>
+        </main>
+
+        <footer className="flex flex-col sm:flex-row gap-3 sm:gap-3">
+          <button
+            type="button"
+            onClick={handleCancel}
+            className="flex-1 px-4 py-2.5 rounded-lg font-medium text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-gray-300 dark:focus:ring-gray-500"
+            aria-label="Cancel action"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleConfirm}
+            className="flex-1 px-4 py-2.5 rounded-lg font-medium text-white bg-red-500 hover:bg-red-600 transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-red-300 dark:focus:ring-red-500 shadow-lg hover:shadow-xl"
+            aria-label="Confirm action"
+          >
+            Confirm
+          </button>
+        </footer>
+      </dialog>
+    </div>
+  );
+}

--- a/src/components/InputModal.tsx
+++ b/src/components/InputModal.tsx
@@ -1,0 +1,168 @@
+"use client";
+import React, { useEffect, useState } from "react";
+import toast from "react-hot-toast";
+
+interface InputModalProps {
+  isOpen: boolean;
+  title: string;
+  message?: string;
+  placeholder?: string;
+  onConfirm: (value: string) => void;
+  onCancel: () => void;
+}
+
+export default function InputModal({
+  isOpen,
+  title,
+  message,
+  placeholder = "Enter value...",
+  onConfirm,
+  onCancel,
+}: InputModalProps) {
+  const [inputValue, setInputValue] = useState("");
+
+  // Clear input when modal closes
+  useEffect(() => {
+    if (!isOpen) {
+      setInputValue("");
+    }
+  }, [isOpen]);
+
+  const handleKeyPress = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && inputValue.trim()) {
+      handleConfirm();
+    }
+    if (e.key === "Escape") {
+      onCancel();
+    }
+  };
+
+  const handleConfirm = async () => {
+    if (!inputValue.trim()) {
+      toast.error("Please enter a valid value!");
+      return;
+    }
+    await onConfirm(inputValue);
+    setInputValue(""); // Reset input field
+  };
+
+  const handleCancel = () => {
+    onCancel();
+    toast("Action canceled", { icon: "⚪" });
+    setInputValue("");
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-4 animate-in fade-in duration-200"
+      role="presentation"
+      aria-hidden="false"
+    >
+      <dialog
+        open={isOpen}
+        className="bg-white dark:bg-gray-800 rounded-xl shadow-2xl p-6 w-full max-w-md mx-auto transform animate-in zoom-in-95 duration-200"
+        role="dialog"
+        aria-labelledby="input-modal-title"
+        aria-describedby="input-modal-description"
+        aria-modal="true"
+      >
+        <header className="flex items-center justify-center w-12 h-12 mx-auto mb-4 bg-blue-100 dark:bg-blue-900/30 rounded-full">
+          <svg
+            className="w-6 h-6 text-blue-600 dark:text-blue-400"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-modal="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 6v6m0 0v6m0-6h6m-6 0H6"
+            />
+          </svg>
+        </header>
+
+        <main className="text-center mb-6">
+          <h2
+            id="confirm-modal-title"
+            className="text-xl font-semibold mb-2 text-gray-900 dark:text-gray-100"
+          >
+            {title}
+          </h2>
+          {message && (
+            <p
+              id="confirm-modal-description"
+              className="text-sm text-gray-600 dark:text-gray-300 leading-relaxed mb-4"
+            >
+              {message}
+            </p>
+          )}
+        </main>
+
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            handleConfirm();
+          }}
+          className="mb-6"
+        >
+          <fieldset className="mb-6">
+            <legend className="sr-only">Enter skill information</legend>
+            <label htmlFor="skill-input" className="sr-only">
+              Skill name
+            </label>
+            <input
+              id="skill-input"
+              type="text"
+              value={inputValue}
+              onChange={(e) => setInputValue(e.target.value)}
+              onKeyDown={handleKeyPress}
+              placeholder={placeholder}
+              autoFocus
+              required
+              aria-describedby="input-help"
+              className="w-full px-4 py-3 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400 focus:border-transparent transition-all duration-200"
+            />
+          </fieldset>
+
+          <div className="flex flex-col sm:flex-row gap-3 sm:gap-3">
+            <button
+              type="button"
+              onClick={handleCancel}
+              className="flex-1 px-4 py-2.5 rounded-lg font-medium text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-gray-300 dark:focus:ring-gray-500"
+              aria-label="Cancel adding skill"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={!inputValue.trim()}
+              className="flex-1 px-4 py-2.5 rounded-lg font-medium text-white bg-blue-500 hover:bg-blue-600 disabled:bg-gray-300 dark:disabled:bg-gray-600 disabled:cursor-not-allowed transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-blue-300 dark:focus:ring-blue-500 shadow-lg hover:shadow-xl disabled:shadow-none"
+              aria-label="Add new skill"
+            >
+              Add Skill
+            </button>
+          </div>
+        </form>
+
+        {/* Keyboard hint */}
+        <aside id="input-help" className="mt-3 text-center" aria-live="polite">
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            Press{" "}
+            <kbd className="px-1.5 py-0.5 text-xs bg-gray-100 dark:bg-gray-700 rounded">
+              Enter
+            </kbd>{" "}
+            to confirm or{" "}
+            <kbd className="px-1.5 py-0.5 text-xs bg-gray-100 dark:bg-gray-700 rounded">
+              Esc
+            </kbd>{" "}
+            to cancel
+          </p>
+        </aside>
+      </dialog>
+    </div>
+  );
+}


### PR DESCRIPTION
This pull request introduces two new modal components, `ConfirmModal` and `InputModal`, to streamline user interactions for confirmation and input collection. These components enhance the application's usability with accessible and customizable modals, providing a seamless user experience. Below are the key changes grouped by theme:

### New Modal Components

**Confirmation Modal:**
- Added `ConfirmModal` component to display a customizable confirmation dialog with "Confirm" and "Cancel" actions. Includes optional success and cancellation toast notifications. (`src/components/ConfirmModal.tsx`, [src/components/ConfirmModal.tsxR1-R104](diffhunk://#diff-75f49dda0af3e5cf01a2a3aed896bf0e49c60f69b8017a8aeeb6809fcde44ddcR1-R104))

**Input Modal:**
- Added `InputModal` component to collect user input with validation and accessibility features. Includes keyboard shortcuts (Enter for confirm, Escape for cancel) and optional toast notifications. (`src/components/InputModal.tsx`, [src/components/InputModal.tsxR1-R168](diffhunk://#diff-8cb5d68a32d7dcd815052c759594cfc53d13771390ac100328bd38f13f53df2cR1-R168))