### PR TITLE
refactor: ensure single PrismaClient instance for better performance

### DIFF
--- a/src/lib/authOptions.ts
+++ b/src/lib/authOptions.ts
@@ -3,9 +3,8 @@ import EmailProvider from "next-auth/providers/email";
 import { PrismaAdapter } from "@next-auth/prisma-adapter";
 import type { Session } from "next-auth";
 import type { JWT } from "next-auth/jwt";
-import { PrismaClient } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
 
-const prisma = new PrismaClient();
 export const authOptions = {
   adapter: PrismaAdapter(prisma),
   providers: [

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,3 +1,7 @@
 import { PrismaClient } from "@prisma/client";
 
-export const prisma = new PrismaClient();
+// Ensure a single PrismaClient instance across hot reloads (Next.js dev)
+const globalForPrisma = globalThis as { prisma?: PrismaClient };
+
+export const prisma =
+  globalForPrisma.prisma ?? (globalForPrisma.prisma = new PrismaClient());


### PR DESCRIPTION
This pull request refactors the initialization of the `PrismaClient` to ensure a single instance is maintained across hot reloads in a Next.js development environment. The changes improve resource management and prevent multiple instances of `PrismaClient` from being created during development.

### Refactoring of `PrismaClient` initialization:

* [`src/lib/authOptions.ts`](diffhunk://#diff-afbe45caa99110b586db5d710ca3366814ef3796bbf856d23c05de813704f909L6-L8): Updated the import of `prisma` to use the shared instance from `src/lib/prisma.ts` instead of creating a new `PrismaClient` instance.
* [`src/lib/prisma.ts`](diffhunk://#diff-748dde6bfd01eb7864027ae5e6f0b73c5a1f99efd6e98718ea8aa7e7a98d0fc1L3-R7): Refactored the code to ensure a single `PrismaClient` instance is shared across hot reloads by utilizing the `globalThis` object. This prevents multiple instances from being created during development.