### PR TITLE
update: add profile fields and avatar to User model, update Skill table

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,10 @@ const nextConfig: NextConfig = {
         protocol: "https",
         hostname: "lh3.googleusercontent.com",
       },
+      {
+        protocol: "https",
+        hostname: "utfs.io",
+      },
     ],
   },
 };

--- a/prisma/migrations/20250802231944_add_profile_fields/migration.sql
+++ b/prisma/migrations/20250802231944_add_profile_fields/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "public"."Skill" ADD COLUMN     "order" INTEGER NOT NULL DEFAULT 0;
+
+-- AlterTable
+ALTER TABLE "public"."User" ADD COLUMN     "city" TEXT,
+ADD COLUMN     "country" TEXT,
+ADD COLUMN     "profileVisible" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN     "state" TEXT;

--- a/prisma/migrations/20250803010626_add_avatar_to_user/migration.sql
+++ b/prisma/migrations/20250803010626_add_avatar_to_user/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "public"."User" ADD COLUMN     "avatar" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,20 +12,25 @@ model User {
   name                 String?
   email                String        @unique
   image                String?
+  avatar               String?
   bio                  String?
   location             String?
+  city                 String?
+  state                String?
+  country              String?
+  profileVisible       Boolean       @default(true)
   isPro                Boolean       @default(false)
   isVerified           Boolean       @default(false)
   createdAt            DateTime      @default(now())
   emailVerified        DateTime?
-  accounts             Account[]
+  skills               Skill[]
   listings             Listing[]
   messagesSent         Message[]     @relation("FromMessages")
   messagesReceived     Message[]     @relation("ToMessages")
-  sessions             Session[]
-  skills               Skill[]
   swapRequestsReceived SwapRequest[] @relation("Recipient")
   swapRequests         SwapRequest[] @relation("Requester")
+  accounts             Account[]
+  sessions             Session[]
 }
 
 model Message {


### PR DESCRIPTION
This pull request introduces several updates to enhance functionality and improve data modeling in the application. Key changes include expanding the `User` model with new fields, modifying database migrations to support these updates, and adding a new hostname for external image loading in the Next.js configuration.

### Database schema updates:

* [`prisma/migrations/20250802231944_add_profile_fields/migration.sql`](diffhunk://#diff-fabbb099d5fe970fbf4a7b2de37b011ea8c34b09c89c18ae34d912f6fd4c75c9R1-R8): Added new fields to the `User` table (`city`, `state`, `country`, `profileVisible`) and a new `order` column to the `Skill` table with a default value of `0`.
* [`prisma/migrations/20250803010626_add_avatar_to_user/migration.sql`](diffhunk://#diff-65a4a4a6a80548232c7284532f745db23109195bbf5b183ae66898c8eceaf821R1-R2): Added an `avatar` column to the `User` table to store user profile images.

### Prisma schema updates:

* [`prisma/schema.prisma`](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR15-R33): Updated the `User` model to include new fields (`avatar`, `city`, `state`, `country`, `profileVisible`) and adjusted relations for `skills`, `accounts`, and `sessions`.

### Next.js configuration update:

* [`next.config.ts`](diffhunk://#diff-e3f38f2f0e7ba92f0dd56c086ec5de704229d58d5371e8cc57e43961757d8c7bR10-R13): Added `utfs.io` as an allowed hostname for external images in the Next.js `images.remotePatterns` configuration.