### PR TITLE
refactor: remove unused ProfilePageProps interface declaration

### DIFF
--- a/src/app/[username]/page.tsx
+++ b/src/app/[username]/page.tsx
@@ -2,11 +2,16 @@ import { notFound } from "next/navigation";
 import { prisma } from "@/lib/prisma";
 import Image from "next/image";
 
-interface ProfilePageProps {
-  params: { username: string };
-}
+// interface ProfilePageProps {
+//   params: { username: string };
+// }
 
-export default async function UserProfilePage({ params }: ProfilePageProps) {
+// export default async function UserProfilePage({ params }: ProfilePageProps) {
+export default async function UserProfilePage({
+  params,
+}: {
+  params: { username: string };
+}) {
   const { username } = params;
 
   const user = await prisma.user.findUnique({


### PR DESCRIPTION
This pull request makes a small change to the type definition for the `UserProfilePage` component in `src/app/[username]/page.tsx`. The explicit `ProfilePageProps` interface was commented out and replaced with an inline type definition for the `params` prop. ([src/app/[username]/page.tsxL5-R14](diffhunk://#diff-56644ebb6593fc0ea37dcca0c95d6a02369c2096f3cf60541dc050815429a891L5-R14))