### PR TITLE
refactor: change import to type for Prisma in skills route

### DIFF
--- a/src/app/api/profile/skills/route.ts
+++ b/src/app/api/profile/skills/route.ts
@@ -1,7 +1,7 @@
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/authOptions";
 import { prisma } from "@/lib/prisma";
-import { Prisma } from "@prisma/client";
+import type { Prisma } from "@prisma/client";
 import { NextResponse } from "next/server";
 
 export async function POST(req: Request) {


### PR DESCRIPTION
This pull request makes a minor improvement to the import statements in `src/app/api/profile/skills/route.ts` by switching the import of `Prisma` to use TypeScript's `type` import syntax. This helps ensure that only type information is imported, which can reduce bundle size and clarify usage.

* Changed `Prisma` import to use `type` import syntax for improved type safety and clarity.