### PR TITLE
refactor: remove unused Prisma import and streamline transactions

### DIFF
--- a/src/app/api/profile/skills/route.ts
+++ b/src/app/api/profile/skills/route.ts
@@ -20,9 +20,14 @@ export async function POST(req: Request) {
     }
 
     const trimmedName = name.trim();
+    type TransactionClient = Parameters<typeof prisma.$transaction>[0] extends (
+      arg: infer U
+    ) => any
+      ? U
+      : never;
 
     // Use transaction to prevent race conditions and ensure data consistency
-    const skill = await prisma.$transaction(async (tx) => {
+    const skill = await prisma.$transaction(async (tx: TransactionClient) => {
       // Get user and verify existence
       const email =
         typeof session.user?.email === "string"

--- a/src/app/api/profile/skills/route.ts
+++ b/src/app/api/profile/skills/route.ts
@@ -1,7 +1,7 @@
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/authOptions";
 import { prisma } from "@/lib/prisma";
-import type { Prisma } from "@prisma/client";
+// import type { Prisma } from "@prisma/client";
 import { NextResponse } from "next/server";
 
 export async function POST(req: Request) {
@@ -22,69 +22,67 @@ export async function POST(req: Request) {
     const trimmedName = name.trim();
 
     // Use transaction to prevent race conditions and ensure data consistency
-    const skill = await prisma.$transaction(
-      async (tx: Prisma.TransactionClient) => {
-        // Get user and verify existence
-        const email =
-          typeof session.user?.email === "string"
-            ? session.user.email
-            : undefined;
-        if (!email) {
-          throw new Error("User not found");
-        }
-
-        const user = await tx.user.findUnique({
-          where: { email },
-          select: { id: true },
-        });
-
-        if (!user) {
-          throw new Error("User not found");
-        }
-
-        // Check for duplicate skill names (optional - removes duplicates)
-        const existingSkill = await tx.skill.findFirst({
-          where: {
-            userId: user.id,
-            name: {
-              equals: trimmedName,
-              mode: "insensitive", // Case-insensitive check
-            },
-          },
-        });
-
-        if (existingSkill) {
-          return NextResponse.json(
-            { error: "Skill already exists" },
-            { status: 409 }
-          );
-        }
-
-        // Get the highest order number for this user's skills
-        const lastSkill = await tx.skill.findFirst({
-          where: { userId: user.id },
-          orderBy: { order: "desc" },
-          select: { order: true },
-        });
-
-        // Use larger increments (1000) to allow for future reordering
-        const newOrder = (lastSkill?.order || 0) + 1000;
-
-        // Create the new skill
-        return await tx.skill.create({
-          data: {
-            name: trimmedName,
-            userId: user.id,
-            order: newOrder,
-          },
-          select: {
-            id: true,
-            name: true,
-            order: true,
-          },
-        });
+    const skill = await prisma.$transaction(async (tx) => {
+      // Get user and verify existence
+      const email =
+        typeof session.user?.email === "string"
+          ? session.user.email
+          : undefined;
+      if (!email) {
+        throw new Error("User not found");
       }
-    );
+
+      const user = await tx.user.findUnique({
+        where: { email },
+        select: { id: true },
+      });
+
+      if (!user) {
+        throw new Error("User not found");
+      }
+
+      // Check for duplicate skill names (optional - removes duplicates)
+      const existingSkill = await tx.skill.findFirst({
+        where: {
+          userId: user.id,
+          name: {
+            equals: trimmedName,
+            mode: "insensitive", // Case-insensitive check
+          },
+        },
+      });
+
+      if (existingSkill) {
+        return NextResponse.json(
+          { error: "Skill already exists" },
+          { status: 409 }
+        );
+      }
+
+      // Get the highest order number for this user's skills
+      const lastSkill = await tx.skill.findFirst({
+        where: { userId: user.id },
+        orderBy: { order: "desc" },
+        select: { order: true },
+      });
+
+      // Use larger increments (1000) to allow for future reordering
+      const newOrder = (lastSkill?.order || 0) + 1000;
+
+      // Create the new skill
+      return await tx.skill.create({
+        data: {
+          name: trimmedName,
+          userId: user.id,
+          order: newOrder,
+        },
+        select: {
+          id: true,
+          name: true,
+          order: true,
+        },
+      });
+    });
 
     return NextResponse.json(skill);
   } catch (error) {
@@ -127,7 +125,7 @@ export async function DELETE(req: Request) {
     }
 
     // Use transaction to ensure user owns the skill being deleted
-    await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
+    await prisma.$transaction(async (tx) => {
       // Get user ID
       const email =
         typeof session.user?.email === "string"

--- a/src/types/middleware.ts
+++ b/src/types/middleware.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export function middleware(req: NextRequest) {
+  const comingSoonEnabled = true; // toggle when ready to launch
+  const isDev = process.env.NODE_ENV === "development";
+
+  // Allow everything in dev
+  if (isDev) return NextResponse.next();
+
+  // Allow API routes, assets, and NextAuth callbacks if needed
+  if (
+    req.nextUrl.pathname.startsWith("/api") ||
+    req.nextUrl.pathname.startsWith("/_next") ||
+    req.nextUrl.pathname.startsWith("/favicon.ico")
+  ) {
+    return NextResponse.next();
+  }
+
+  // If Coming Soon enabled, redirect everything to root
+  if (comingSoonEnabled && req.nextUrl.pathname !== "/") {
+    return NextResponse.redirect(new URL("/", req.url));
+  }
+
+  return NextResponse.next();
+}


### PR DESCRIPTION
This pull request introduces a new middleware for handling "Coming Soon" redirects and simplifies transaction handling in the profile skills API route. The most important changes are grouped below:

**Middleware Addition:**

* Added a new `middleware` function in `src/types/middleware.ts` to enable a "Coming Soon" mode, which redirects all non-API and non-asset requests to the homepage unless in development mode.

**API Transaction Simplification:**

* Simplified transaction handling in `src/app/api/profile/skills/route.ts` by removing explicit typing for the transaction client, relying on Prisma's inference for cleaner code. This affects both the `POST` and `DELETE` handlers. [[1]](diffhunk://#diff-dfa7be7c3585b63267072238b265563fb354e665a80e927ce79f6505aaaa1765L25-R25) [[2]](diffhunk://#diff-dfa7be7c3585b63267072238b265563fb354e665a80e927ce79f6505aaaa1765L130-R128)
* Removed an unnecessary import of the `Prisma` type in `src/app/api/profile/skills/route.ts` for further code cleanup.
* Minor code cleanup in the transaction block for the `POST` handler to improve readability.