### PR TITLE
refactor: add TransactionClient type for improved type safety

### DIFF
--- a/src/app/api/profile/skills/route.ts
+++ b/src/app/api/profile/skills/route.ts
@@ -2,6 +2,7 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/authOptions";
 import { prisma } from "@/lib/prisma";
 // import type { Prisma } from "@prisma/client";
+import type { TransactionClient } from "@/types/prisma";
 import { NextResponse } from "next/server";
 
 export async function POST(req: Request) {
@@ -20,11 +21,6 @@ export async function POST(req: Request) {
     }
 
     const trimmedName = name.trim();
-    type TransactionClient = Parameters<typeof prisma.$transaction>[0] extends (
-      arg: infer U
-    ) => any
-      ? U
-      : never;
 
     // Use transaction to prevent race conditions and ensure data consistency
     const skill = await prisma.$transaction(async (tx: TransactionClient) => {

--- a/src/types/prisma.ts
+++ b/src/types/prisma.ts
@@ -1,0 +1,9 @@
+import { PrismaClient } from "@prisma/client";
+
+// export type TransactionClient = Omit<
+//   PrismaClient,
+//   "$connect" | "$disconnect" | "$on" | "$transaction" | "$use"
+// >;
+export type TransactionClient = Parameters<
+  Parameters<PrismaClient["$transaction"]>[0]
+>[0];


### PR DESCRIPTION
This pull request refactors how the `TransactionClient` type is defined and imported for use in the `profile/skills` API route. The main improvement is moving the type definition out of the route handler and into a dedicated types file, which helps keep the codebase organized and improves type reuse.

Type definition and usage improvements:

* Moved the definition of `TransactionClient` from inside the `POST` handler in `src/app/api/profile/skills/route.ts` to a new shared types file, `src/types/prisma.ts`. [[1]](diffhunk://#diff-dfa7be7c3585b63267072238b265563fb354e665a80e927ce79f6505aaaa1765L23-L27) [[2]](diffhunk://#diff-2d94a72796043c280390fd5d67e23a93ff49b9713086a1c83e5046842432cbcaR1-R9)
* Updated the import statement in `src/app/api/profile/skills/route.ts` to import `TransactionClient` from the new types file instead of defining it locally.